### PR TITLE
Rescaling the viewport does not rescale the host window when docked.

### DIFF
--- a/SqrMelon/main.py
+++ b/SqrMelon/main.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import traceback
+from types import MethodType
 from typing import Any, cast, Optional, TextIO
 
 import icons
@@ -114,6 +115,7 @@ class App(QMainWindowState):
         window = self.createWindowContainer(self.__sceneView, self)
         window.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         viewDock = self._addDockWidget(window, '3D View', where=Qt.DockWidgetArea.TopDockWidgetArea)
+        self.__sceneView.isFloating = MethodType(lambda self: viewDock.isFloating(), self.__sceneView)
         self.__viewDock = viewDock  # Need this for F11 feature
         self.__restoreFullScreenInfo: Optional[tuple[QSize, bool]] = None
         logDock = self._addDockWidget(PyDebugLog.create(), 'Python log', where=Qt.DockWidgetArea.TopDockWidgetArea)

--- a/SqrMelon/sceneview3d.py
+++ b/SqrMelon/sceneview3d.py
@@ -83,9 +83,10 @@ class SceneView(QOpenGLWindow):
     def setPreviewRes(self, widthOverride: Optional[int], heightOverride: Optional[int], scale: float) -> None:
         if widthOverride is not None:
             assert heightOverride is not None
-            x = self.parent().width() - self.width()
-            y = self.parent().height() - self.height()
-            self.parent().setGeometry(self.parent().x(), self.parent().y(), widthOverride + x, heightOverride + y)
+            if self.isFloating():
+                x = self.parent().width() - self.width()
+                y = self.parent().height() - self.height()
+                self.parent().setGeometry(self.parent().x(), self.parent().y(), widthOverride + x, heightOverride + y)
         self._previewRes = widthOverride, heightOverride, scale
         gSettings.setValue('GLViewScale', scale)
         self.__onResize()


### PR DESCRIPTION
When the viewport is docket within the app window and other circumstances apply (e.g., the app window is not maximized, or it is maximized but you have a secondary monitor to the right), rescaling the viewport rescales the app window.

This PR changes this behavior:
* If the viewport is undocked, the behavior remains the same.
* If the viewport is docked, now changing Tools/Preview Resolution value do change the scene resolution but not the docked viewport panel size.
